### PR TITLE
Add state_class to device config payload

### DIFF
--- a/py_power_meter_monitor/workers/iec_62056_obis_data_set_mqtt_logger.py
+++ b/py_power_meter_monitor/workers/iec_62056_obis_data_set_mqtt_logger.py
@@ -141,6 +141,7 @@ def get_device_class(obis_data_set: ObisDataSet) -> dict[str, str]:
         return {}
 
     device_class = device_class_by_unit.get(obis_data_set.unit, None)
+    state_class = state_class_by_unit.get(obis_data_set.unit, None)
 
     return {
         "unit_of_measurement": obis_data_set.unit,
@@ -149,6 +150,13 @@ def get_device_class(obis_data_set: ObisDataSet) -> dict[str, str]:
                 "device_class": device_class,
             }
             if device_class
+            else {}
+        ),
+        **(
+            {
+                "state_class": state_class,
+            }
+            if state_class
             else {}
         ),
     }
@@ -162,4 +170,14 @@ device_class_by_unit = {
     "kWh": "energy",
     "A": "current",
     "V": "voltage",
+}
+
+state_class_by_unit = {
+    "°C": "measurement",
+    "W": "measurement",
+    "kW": "measurement",
+    "Wh": "total_increasing",
+    "kWh": "total_increasing",
+    "A": "measurement",
+    "V": "measurement",
 }


### PR DESCRIPTION
## :memo: Summary

This adds the `state_class` attribute to the sensor configuration payload. It is determined via the unit of measurement, which might be crude but should work in this case.

This enables support for Home Assistant's new long term statistics and energy dashboard.